### PR TITLE
feat: Add ubuntu 24.04 (NR-248002)

### DIFF
--- a/.github/workflows/ci_build_docker_runner.yml
+++ b/.github/workflows/ci_build_docker_runner.yml
@@ -37,6 +37,7 @@ jobs:
           - ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          - ubuntu2404
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,21 +19,3 @@ jobs:
           package_version: '1.52.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"
-
-  # TEST ubuntu24
-  molecule-packaging-tests-24:
-    name: Launch molecule tests with infra-agent package
-    runs-on: ubuntu-latest
-    env:
-      TESTING: 'true'
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Molecule tests
-        uses: ./
-        with:
-          repo_base_url: 'http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/gs-test-otel'
-          package_name: 'nr-otel-collector'
-          package_version: '0.6.0'
-          gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
-          platforms: "ubuntu1604,ubuntu2204,ubuntu2404"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,3 +19,21 @@ jobs:
           package_version: '1.52.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"
+
+  # TEST ubuntu24
+  molecule-packaging-tests-24:
+    name: Launch molecule tests with infra-agent package
+    runs-on: ubuntu-latest
+    env:
+      TESTING: 'true'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Molecule tests
+        uses: ./
+        with:
+          repo_base_url: 'http://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/gs-test-otel'
+          package_name: 'nr-otel-collector'
+          package_version: '0.6.0'
+          gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+          platforms: "ubuntu1604,ubuntu2204,ubuntu2404"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   molecule-packaging-tests:
     name: Launch molecule tests with infra-agent package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TESTING: 'true'
     steps:
@@ -16,6 +16,6 @@ jobs:
         with:
           repo_base_url: 'https://download.newrelic.com/infrastructure_agent'
           package_name: 'newrelic-infra'
-          package_version: '1.48.4'
+          package_version: '1.52.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-molecule/default/molecule.yml
+# having the molecule.yml in .gitignore prevents the molecule converge to run.
+# https://github.com/ansible/molecule/issues/4117
+
+#molecule/default/molecule.yml

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Github action that tests the correct installation of a given package and version
  - ubuntu1804
  - ubuntu2004
  - ubuntu2204
+ - ubuntu2404
 
 ## Example usage
 
@@ -44,7 +45,7 @@ on:
 jobs:
   molecule-packaging-tests:
     name: Launch molecule tests with infra-agent package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/action.yml
+++ b/action.yml
@@ -23,8 +23,7 @@ runs:
     - name: Configure Molecule and Ansible
       shell: bash
       run: |
-        python3 -m pip install molecule ansible ansible-core
-        python3 -m pip install "molecule-plugins[docker]"
+        python3 -m pip install molecule==24.2.1 ansible==9.5.1 ansible-core==2.16.6 "molecule-plugins[docker]==23.5.3"
     - name: Prepare OS versions
       shell: bash
       run: ${GITHUB_ACTION_PATH}/prepare_platform.sh ${{ inputs.platforms }}

--- a/action.yml
+++ b/action.yml
@@ -23,10 +23,8 @@ runs:
     - name: Configure Molecule and Ansible
       shell: bash
       run: |
-        sudo pipx uninstall ansible-core
-        sudo pip3 install molecule[docker]==4.0.4
-        sudo pip3 install 'rich>=10.0.0,<11.0.0'
-        sudo pip3 install ansible-lint[community]==5.3.2
+        python3 -m pip install molecule ansible ansible-core
+        python3 -m pip install "molecule-plugins[docker]"
     - name: Prepare OS versions
       shell: bash
       run: ${GITHUB_ACTION_PATH}/prepare_platform.sh ${{ inputs.platforms }}

--- a/molecule/default/dockerfiles/ubuntu1604
+++ b/molecule/default/dockerfiles/ubuntu1604
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update \
-    && apt-get install -y init ca-certificates sudo curl python3 apt-transport-https\
+    && apt-get install -y init ca-certificates sudo curl apt-transport-https python-minimal\
     && apt-get clean all
 
 # Adding fake systemctl

--- a/molecule/default/dockerfiles/ubuntu2404
+++ b/molecule/default/dockerfiles/ubuntu2404
@@ -1,0 +1,10 @@
+FROM ubuntu:24.04
+
+RUN apt-get update \
+    && apt-get install -y init gpg ca-certificates sudo curl \
+    && apt-get clean all
+
+# Adding fake systemctl
+RUN curl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -o /usr/local/bin/systemctl
+
+CMD ["/usr/local/bin/systemctl"]

--- a/prepare_platform.sh
+++ b/prepare_platform.sh
@@ -24,7 +24,7 @@ This is a bash script to make generate a Molecule configutaion.
     exit
 fi
 
-available_platforms=("al2" "al2023" "centos7" "centos8" "debian-bullseye" "debian-buster" "debian-bookworm" "redhat8" "redhat9" "suse15.2" "suse15.3" "suse15.4" "suse15.5" "ubuntu1604" "ubuntu1804" "ubuntu2004" "ubuntu2204")
+available_platforms=("al2" "al2023" "centos7" "centos8" "debian-bullseye" "debian-buster" "debian-bookworm" "redhat8" "redhat9" "suse15.2" "suse15.3" "suse15.4" "suse15.5" "ubuntu1604" "ubuntu1804" "ubuntu2004" "ubuntu2204" "ubuntu2404")
 
 # check_platforms verifies that the provided platforms are available
 check_platforms() {
@@ -71,7 +71,7 @@ set_platforms_config() {
         fi
 
         # set python interpreter groups
-        if [[ $PLATFORM == "al2" || $PLATFORM == "centos7" ]]; then
+        if [[ $PLATFORM == "al2" || $PLATFORM == "centos7" || $PLATFORM == "ubuntu1604" ]]; then
             yq -i ".platforms[] |= select(.name == \"$PLATFORM\") += {\"groups\": [\"python\"]}" $FILE_PATH
         else
             yq -i ".platforms[] |= select(.name == \"$PLATFORM\") += {\"groups\": [\"python3\"]}" $FILE_PATH


### PR DESCRIPTION
# Changed
- Adding Ubuntu 24.04 to supported OS

# Breaking
- Updates the ansible-core version to 2.16 so is [compatible](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) with python 3.12 present in ubuntu 24. This comes with the need to run the action within **ubuntu-22.04 (`ubuntu-latest` at the moment)** runner and to make use of python2 as interpreter for ubuntu 16 with supports python 3.5 (incompatible with ansible)
