### PR TITLE
fix: ubuntu16 pre-build container

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,8 +6,13 @@ jobs:
   molecule-packaging-tests:
     name: Launch molecule tests with infra-agent package
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # test building and using pre-build containers.
+        build_docker: ["true",""]
     env:
-      TESTING: 'true'
+      TESTING: ${{ matrix.build_docker}}
     steps:
       - uses: actions/checkout@v2
 

--- a/prepare_platform.sh
+++ b/prepare_platform.sh
@@ -63,6 +63,13 @@ set_platforms_config() {
             yq -i ".platforms[] |= select(.name == \"$PLATFORM\") += {\"image\":\"$PLATFORM\", \"dockerfile\": \"./dockerfiles/$PLATFORM\"}" $FILE_PATH
         else
             yq -i ".platforms[] |= select(.name == \"$PLATFORM\") += {\"image\":\"ghcr.io/newrelic/pkg-installation-testing-action-$PLATFORM\"}" $FILE_PATH
+
+            # Prevent molecule to install extra tools in the pre-build image
+            # https://ansible.readthedocs.io/projects/molecule/guides/custom-image/
+            # ubuntu16 python 2 installation was being corrupted by this behaivor.
+            if [[ $PLATFORM == "ubuntu1604" ]]; then
+                yq -i ".platforms[] |= select(.name == \"$PLATFORM\") += {\"pre_build_image\": true}" $FILE_PATH
+            fi
         fi
 
         # debian based distributions need to set up the init command


### PR DESCRIPTION
Molecule was installing extra tools over the pre-build container which made the python2 installation failed.
see following verbose log:
```
TASK [Create Dockerfiles from image names] *************************************
--- before
+++ after: /home/ubuntu/.ansible/tmp/ansible-local-58232knngsotc/tmpx4ij7gqi/Dockerfile.j2
@@ -0,0 +1,11 @@
+# Molecule managed
+
+FROM ghcr.io/newrelic/pkg-installation-testing-action-ubuntu1604:latest
+
+
+RUN if [ $(command -v apt-get) ]; then export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 python3-apt aptitude rsync && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute rsync && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl bash iproute rsync && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash iproute2 rsync && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates rsync; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 rsync && xbps-remove -O; fi
```

This PR adds `pre_build_image` to that container to prevent this 