### PR TITLE
fix centos 7 repo url

### DIFF
--- a/molecule/default/dockerfiles/centos7
+++ b/molecule/default/dockerfiles/centos7
@@ -2,8 +2,8 @@ FROM centos:7
 
 ## Updating the default repo to vault.centos.org
 ## Context: https://forketyfork.medium.com/centos-8-no-urls-in-mirrorlist-error-3f87c3466faa
-#RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-#    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
+    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
 
 # Run a system update so the system doesn't overwrite the fake systemctl later
 RUN yum -y update


### PR DESCRIPTION
Centos 7 mirrors are not working properly:
```
#0 0.956 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
#0 0.956 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
```

https://github.com/newrelic/infrastructure-agent/actions/runs/9893255675/job/27363022219#step:2:546

![Screenshot 2024-07-12 at 11 02 52](https://github.com/user-attachments/assets/f218dee6-b1f9-44e9-8b02-129250607224)
