### PR TITLE
Add script to recreate v1 tag

### DIFF
--- a/scripts/recreate-tag.sh
+++ b/scripts/recreate-tag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script recreates tag v1 in the repository
+# It will:
+# 1. Fetch all tags and prune them
+# 2. Checkout the main branch
+# 3. Delete the tag v1
+# 4. Push the deletion of the tag v1
+# 5. Create the tag v1
+
+
+TAG_NAME="v1"
+
+git fetch --tags --prune-tags -f
+git checkout origin/main
+git tag -d $TAG_NAME
+git push --delete origin $TAG_NAME
+git tag $TAG_NAME
+git push origin $TAG_NAME


### PR DESCRIPTION
## Summary
Introduces `recreate-tag.sh`, a script for automating the recreation of Git tag `v1`

* Automates fetching, deleting, and recreating tags on both local and remote repositories.

## Usage
Run `./recreate-tag.sh 

## Note
Use with caution in production environments to avoid disrupting release workflows.