### PR TITLE
ci:Support Rocky Linux

### DIFF
--- a/.github/workflows/ci_build_docker_runner.yml
+++ b/.github/workflows/ci_build_docker_runner.yml
@@ -34,6 +34,7 @@ jobs:
           - debian-bookworm
           - redhat8
           - redhat9
+          - rocky9
           - suse15.2
           - suse15.3
           - suse15.4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           repo_base_url: 'https://download.newrelic.com/infrastructure_agent'
           package_name: 'newrelic-infra'
-          package_version: '1.57.1'
+          package_version: '1.63.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
-          platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,rocky9,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Github action that tests the correct installation of a given package and version
  - debian-bookworm
  - redhat8
  - redhat9
+ - rocky9
  - suse15.2
  - suse15.3
  - suse15.4
@@ -57,7 +58,7 @@ jobs:
           package_name: 'newrelic-infra'
           package_version: '1.36.0'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
-          platforms: "al2,al2022,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"
+          platforms: "al2,al2022,centos7,centos8,debian-bullseye,debian-buster,redhat8,redhat9,rocky9,suse15.2,suse15.3,suse15.4,suse15.5,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"
 ```
 
 

--- a/molecule/default/dockerfiles/rocky9
+++ b/molecule/default/dockerfiles/rocky9
@@ -1,0 +1,11 @@
+FROM rockylinux:9
+
+# Run a system update so the system doesn't overwrite the fake systemctl later
+RUN yum -y update
+
+RUN yum -y install python3 sudo
+
+# Adding fake systemctl
+RUN curl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py -o /usr/local/bin/systemctl
+
+CMD ["/usr/local/bin/systemctl"]

--- a/prepare_platform.sh
+++ b/prepare_platform.sh
@@ -24,7 +24,7 @@ This is a bash script to make generate a Molecule configutaion.
     exit
 fi
 
-available_platforms=("al2" "al2023" "centos7" "centos8" "debian-bullseye" "debian-buster" "debian-bookworm" "redhat8" "redhat9" "suse15.2" "suse15.3" "suse15.4" "suse15.5" "suse15.6" "ubuntu1604" "ubuntu1804" "ubuntu2004" "ubuntu2204" "ubuntu2404")
+available_platforms=("al2" "al2023" "centos7" "centos8" "debian-bullseye" "debian-buster" "debian-bookworm" "redhat8" "redhat9" "rocky9" "suse15.2" "suse15.3" "suse15.4" "suse15.5" "suse15.6" "ubuntu1604" "ubuntu1804" "ubuntu2004" "ubuntu2204" "ubuntu2404")
 
 # check_platforms verifies that the provided platforms are available
 check_platforms() {


### PR DESCRIPTION
# Add Support for Rocky Linux 9 in CI/CD Workflows

This update introduces support for **Rocky Linux 9** in the CI/CD workflows for building, testing, and publishing Docker container images. The following changes were made:

## Docker Build Workflow (`ci_build_docker_runner.yml`)
- Added `rocky9` to the matrix strategy for Dockerfile builds.
- Ensures that a Docker image for Rocky Linux 9 is built and pushed to the GitHub Container Registry (`ghcr.io`).

## Testing Workflow (`testing.yml`)
- Included `rocky9` in the `platforms` list for Molecule tests.
- Ensures that the testing pipeline validates the infrastructure agent package on Rocky Linux 9.

## Platform Preparation Script (`prepare_platform.sh`)
- Verified that `rocky9` is included in the `available_platforms` array.
- Ensured that platform-specific configurations (e.g., Python interpreter groups) are correctly applied to Rocky Linux 9.

## Dockerfile for Rocky Linux 9
- Created a new Dockerfile (`rocky9`) based on the Rocky Linux 9 base image.
- Configured the Dockerfile to install necessary dependencies and include a fake `systemctl` for containerized environments.

These changes ensure that **Rocky Linux 9** is fully integrated into the build, test, and deployment pipelines, aligning with the project's goal of supporting a wide range of Linux distributions.