### PR TITLE
feat: custom command version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,3 +23,12 @@ jobs:
           package_version: '1.72.0'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
           platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-trixie,redhat8,redhat9,redhat10,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+      - name: Custom command test
+        uses: ./
+        with:
+          gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
+          repo_base_url: "http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/preview"
+          package_name: "newrelic-agent-control"
+          package_version: "1.12.0"
+          version_command: "version"
+          platforms: ubuntu2404

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'name of the binary that should be executed after installation'
     required: false
     default: ''
+  version_command:
+    description: 'command or flag used to check the installed version (e.g. "--version" or "version")'
+    required: false
+    default: '--version'
 
 runs:
   using: "composite"
@@ -39,6 +43,7 @@ runs:
         PACKAGE_VERSION: ${{ inputs.package_version }}
         GPG_KEY: ${{ inputs.gpg_key }}
         EXEC_NAME: ${{ inputs.exec_name != '' && inputs.exec_name || inputs.package_name }}
+        VERSION_COMMAND: ${{ inputs.version_command }}
       run: "cd ${GITHUB_ACTION_PATH} && molecule converge"
     - name: Teardown
       shell: bash

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,7 @@
         package_name: "{{ lookup('env', 'PACKAGE_NAME') }}"
         gpg_key: "{{ lookup('env', 'GPG_KEY') }}"
         exec_name: "{{ lookup('env', 'EXEC_NAME') }}"
+        version_command: "{{ lookup('env', 'VERSION_COMMAND') }}"
 
       block:
         - name: Repo setup
@@ -27,6 +28,6 @@
             name: caos.ansible_roles.assert_version
           vars:
             target_versions:
-              - exec: "{{ exec_name }} --version"
+              - exec: "{{ exec_name }} {{ version_command }}"
                 version: "{{ package_version }}"
 


### PR DESCRIPTION
Make version command configurable , this allows testing binaries that do not use the `--version` flag to print the version. 
The change is backward compatible.