### PR TITLE
fix: add Ubuntu 26.04 support by converting GPG key to binary format

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,6 +16,15 @@
           include_role:
             name: caos.ansible_roles.nr_repo_setup
 
+        - name: Fix GPG key format for Ubuntu 26.04
+          shell: |
+            gpg --dearmor < /etc/apt/keyrings/newrelic-infra.gpg > /tmp/newrelic-infra-binary.gpg
+            mv /tmp/newrelic-infra-binary.gpg /etc/apt/keyrings/newrelic-infra.gpg
+            apt-get update
+          when:
+            - ansible_distribution == "Ubuntu"
+            - ansible_distribution_version == "26.04"
+
         - name: Install package
           include_role:
             name: caos.ansible_roles.package_install


### PR DESCRIPTION
## Summary
Adds support for Ubuntu 26.04 (Resolute) package installation testing.

## Problem
Ubuntu 26.04 requires GPG keys in binary format instead of ASCII armored format (similar to Debian Trixie). When using ASCII armored keys, APT shows:
- The key(s) in the keyring /etc/apt/keyrings/newrelic-infra.gpg are ignored as the file has an unsupported filetype
This caused package installation to fail with `NO_PUBKEY` errors.

## Solution
Modified `molecule/default/converge.yml` to:
1. Convert GPG key to binary format using `gpg --dearmor` after repo setup
2. Update APT cache with the fixed key
3. Only applies to Ubuntu 26.04 via conditional `when` clause

The fix only executes when:
- `ansible_distribution == "Ubuntu"`
- `ansible_distribution_version == "26.04"`