### PR TITLE
feat: add Ubuntu 26.04 (Resolute Raccoon) support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           repo_base_url: 'https://download.newrelic.com/infrastructure_agent'
           package_name: 'newrelic-infra'
-          package_version: '1.72.0'
+          package_version: '1.74.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
-          platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-trixie,redhat8,redhat9,redhat10,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404"
+          platforms: "al2,al2023,centos7,centos8,debian-bullseye,debian-trixie,redhat8,redhat9,redhat10,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404,ubuntu2604"
       - name: Custom command test
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ jobs:
         with:
           repo_base_url: 'http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent'
           package_name: 'newrelic-infra'
-          package_version: '1.72.0'
+          package_version: '1.74.1'
           gpg_key: 'https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg'
-          platforms: "al2,al2022,centos7,centos8,debian-bullseye,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204"
+          platforms: "al2,al2022,centos7,centos8,debian-bullseye,redhat8,redhat9,suse15.2,suse15.3,suse15.4,suse15.5,suse15.6,suse15.7,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204,ubuntu2404,ubuntu2604"
 ```
 
 


### PR DESCRIPTION
  Adds Ubuntu 26.04 LTS "Resolute Raccoon" support to the package installation testing action.                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  - Added ubuntu2604 dockerfile under molecule/default/dockerfiles/                                                                                                                                                                                                          
  - Added ubuntu2604 to available_platforms in prepare_platform.sh                                                                                                                                                                                                           
  - Added ubuntu2604 to the platform matrix in ci_build_docker_runner.yml so the Docker image is built and published                                                                                                                                                         
  - Added ubuntu2604 to the test platforms in testing.yml                                                                                                                                                                                                                    
  - Updated README.md supported platforms list and example usage                                                                                                                                                                                                          